### PR TITLE
Towns and Steel Storm: Burning retribution overlay now work.

### DIFF
--- a/_posts/2013-01-03-Games.markdown
+++ b/_posts/2013-01-03-Games.markdown
@@ -132,8 +132,6 @@ Games confirmed to be working
 - [Stacking](http://store.steampowered.com/app/115110/)
 - [Stealth Bastard Deluxe](http://store.steampowered.com/app/209190/)
 - [Steel Storm: Burning Retribution](http://store.steampowered.com/app/96200/)
-> Overlay doesn't work with 64-bit version.
-
 - [Spectraball](http://store.steampowered.com/app/18300/)
 - [Superbrothers: Sword & Sworcery EP](http://store.steampowered.com/app/204060/)
 - [Super Hexagon](http://store.steampowered.com/app/221640/)
@@ -152,9 +150,7 @@ Games confirmed to be working
 - [Thomas Was Alone](http://store.steampowered.com/app/220780/)
 - [Tiny and Big: Grandpa's Leftovers](http://store.steampowered.com/app/205910/)
 - [Titan Attacks!](http://store.steampowered.com/app/203210/)
-- [Towns](http://store.steampowered.com/app/221020/) [Broken overlay](#right_info)
-> Overlay doesn't work with 64-bit java.
-
+- [Towns](http://store.steampowered.com/app/221020/)
 - [Trine 2](http://store.steampowered.com/app/35720/)
 - [Ultratron](http://store.steampowered.com/app/219190/)
 - [Unity of Command: Stalingrad Campaign](http://store.steampowered.com/app/218090/)


### PR DESCRIPTION
The latest steam beta added 64bit support for games (excluding runtime) so now overlay works on java and 64 bit games (on 64bit systems).
