### PR TITLE
FTL, Splice, Conquest of Elisium, Lume Overlay status

### DIFF
--- a/_posts/2013-01-03-Games.markdown
+++ b/_posts/2013-01-03-Games.markdown
@@ -29,7 +29,7 @@ Games confirmed to be working
 - [Champions of Regnum](http://store.steampowered.com/app/222520/)
 - [Closure](http://store.steampowered.com/app/72000/)
 - [Cogs](http://store.steampowered.com/app/26500/)
-- [Conquest of Elysium 3](http://store.steampowered.com/app/211900/) [Broken overlay](#right_info)
+- [Conquest of Elysium 3](http://store.steampowered.com/app/211900/)
 - [Costume Quest](http://store.steampowered.com/app/115100/)
 - [Counter-Strike: Condition Zero](http://store.steampowered.com/app/80/)
 - [Counter-Strike: Source](http://store.steampowered.com/app/240/)
@@ -58,7 +58,7 @@ Games confirmed to be working
 - [Eversion](http://store.steampowered.com/app/33680/)
 - [Expeditions: Conquistador](http://store.steampowered.com/app/237430/)
 - [Frozen Synapse](http://store.steampowered.com/app/98200/)
-- [FTL: Faster Than Light](http://store.steampowered.com/app/212680/) [Broken overlay](#right_info)
+- [FTL: Faster Than Light](http://store.steampowered.com/app/212680/)
 - [Galcon Fusion](http://store.steampowered.com/app/44200/)
 - [Gear Up](http://store.steampowered.com/app/214420/) [Broken overlay](#right_info)
 - [Gratuitous Space Battles](http://store.steampowered.com/app/41800/)
@@ -94,6 +94,8 @@ Games confirmed to be working
 - [Little Inferno](http://store.steampowered.com/app/221260/)
 - [Lugaru HD](http://store.steampowered.com/app/25010/)
 - [Lume](http://store.steampowered.com/app/105100/) [Broken overlay](#right_info)
+> Overlay works only in full-screen mode
+
 - [Magical Diary](http://store.steampowered.com/app/211340/) [Broken overlay](#right_info)
 - [Mare Nostrum](http://store.steampowered.com/app/1230/)
 - [Multiwinia](http://store.steampowered.com/app/1530/)
@@ -125,7 +127,7 @@ Games confirmed to be working
 - [Space Pirates and Zombies](http://store.steampowered.com/app/107200/)
 - [SpaceChem](http://store.steampowered.com/app/92800/)
 - [Spirits](http://store.steampowered.com/app/210170/)
-- [Splice](http://store.steampowered.com/app/209790/) [Broken overlay](#right_info)
+- [Splice](http://store.steampowered.com/app/209790/)
 > Achievements do not unlock.
 [source](http://steamcommunity.com/app/209790/discussions/0/864951657745931480/#c828925216497607741)
 


### PR DESCRIPTION
FTL, Splice and Conquest of Elisium 3 now have working overlay with latest steam release. Lume has working overlay only when full screen.
