### PR TITLE
War for the overlord shows.

### DIFF
--- a/_posts/2013-01-02-Pending.markdown
+++ b/_posts/2013-01-02-Pending.markdown
@@ -27,6 +27,7 @@ Entries with Missing Executable
 - [Scoregasm](http://store.steampowered.com/app/202410/)
 - [Spiral Knights Preview](http://store.steampowered.com/app/99920/)
 - [Starseed Pilgrim](http://store.steampowered.com/app/230980/)
+- [War for the Overworld](http://store.steampowered.com/app/230190/)
 
 Entries with Linux Listed
 ------------------------------
@@ -50,7 +51,6 @@ These show up in the [Steam Database](http://steamdb.info/linux/), but do **NOT*
 - [Snapshot](http://store.steampowered.com/app/204220/)
 - [TRAUMA](http://store.steampowered.com/app/98100/)
 - [The Binding of Isaac](http://store.steampowered.com/app/113200/)
-- [War for the Overworld](http://store.steampowered.com/app/230190/)
 - [Wargame: Airland Battle](http://store.steampowered.com/app/222750/)
 
 Unconfirmed


### PR DESCRIPTION
War for the overlord shows in the Linux game listing (actually since a long while too), just it has nothing to download and gets Missing Executable dialog after install.
