### PR TITLE
Moved War for the Overworld to list of working games.

### DIFF
--- a/_posts/2013-01-02-Pending.markdown
+++ b/_posts/2013-01-02-Pending.markdown
@@ -43,7 +43,6 @@ These show up in the [Steam Database](http://steamdb.info/linux/), but do **NOT*
 - [Spiral Knights](http://store.steampowered.com/app/99900/)
 - [System Shock 2](http://store.steampowered.com/app/238210/)
 - [TRAUMA](http://store.steampowered.com/app/98100/)
-- [War for the Overworld](http://store.steampowered.com/app/230190/)
 
 Unconfirmed
 -----------

--- a/_posts/2013-01-03-Games.markdown
+++ b/_posts/2013-01-03-Games.markdown
@@ -235,6 +235,7 @@ Games confirmed to be working
 - [Uplink](http://store.steampowered.com/app/1510/)
 - [VVVVVV](http://store.steampowered.com/app/70300/)
 - [Waking Mars](http://store.steampowered.com/app/227200/)
+- [War for the Overworld](http://store.steampowered.com/app/230190/)
 - [Wargame: Airland Battle](http://store.steampowered.com/app/222750/)
 - [Wargame: European Escalation](http://store.steampowered.com/app/58610/)
 - [Waveform](http://store.steampowered.com/app/204180/)


### PR DESCRIPTION
The public build of War for the Overworld now works on Linux (Ubuntu 12.04).
