### PR TITLE
Defender's Quest - only overlay doesn't work

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -642,7 +642,7 @@
 	"218410":
 	{
 		"Working": true,
-		"Comment": "Steamworks features are unavailable."
+		"Comment": "Broken overlay."
 	},
 	"218660":
 	{


### PR DESCRIPTION
Previously the comment said Steamworks features didn't work, but trading cards and achievements do work. Only the overlay does not.
