### PR TITLE
Planet Stronghold working

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -1720,8 +1720,7 @@
 	},
 	"291050":
 	{
-		"Working": true,
-		"Comment": "Captures all keyboard input. Alt+Tab and other window manager keystrokes do not work."
+		"Working": true
 	},
 	"293200":
 	{


### PR DESCRIPTION
Tested on Ubuntu 14.04. Alt+Tab not working.
This game captures all keyboard input so that alt+tab, adjusting volume via keyboard, etc. don't work. Games linking SDL 1.2 do this while games using SDL 2.0 do not. This is a pet peeve of mine. I added a comment mentioning it for this game. If other people also find it useful and not clutter from too much useless information, I would be happy to update comments for games that I know to do this.
