### PR TITLE
8BitMMO works

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -1338,6 +1338,11 @@
 	{
 		"Working": true	
 	},
+	"250420":
+	{
+		"Working": true,
+		"Comment": "Overlay works in server-select window, but not in game window."
+	},
 	"250460":
 	{
 		"Working": true


### PR DESCRIPTION
Tested on Ubuntu 14.04. Steam overlay works in the initial server-select window, but not in the game window.
