### PR TITLE
Update GAMES.json

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -1355,11 +1355,6 @@
 	{
 		"Working": true
 	},
-	"250580":
-	{			
-		"Comment": "There is no Linux build, the developers have said it will arrive with patch 1.8, which will be the last patch made to the game",
-		"CommentURL": "http://steamcommunity.com/app/250580/discussions/0/540731691298129556/"
-	},
 	"250600":
 	{
 		"Working": true


### PR DESCRIPTION
Updated Desktop Dungeons (226620) to working, added Heavy Bullets comments, modified Paranautical Activity to show there's no Linux Build
