### PR TITLE
Ignore the lack of json_last_error_msg() on PHP pre‐5.5

### DIFF
--- a/.test.php
+++ b/.test.php
@@ -43,7 +43,7 @@
 		{
 			$games = json_decode( $games, true );
 			
-			$this->assertTrue( json_last_error() === JSON_ERROR_NONE, 'JSON Error: ' . json_last_error_msg() );
+			$this->assertTrue( json_last_error() === JSON_ERROR_NONE, 'JSON Error: ' . ( function_exists( "json_last_error_msg" ) ? json_last_error_msg() : json_last_error() ) );
 			
 			$allowedKeys = Array(
 				'Working'    => 'is_bool',


### PR DESCRIPTION
Use the numeric error output from json_last_error() instead, for PHP >= 5.3.0 <= 5.5.0

Changed as I couldn’t do local phpunit testing with Ubuntu 12.04s shipped `PHP 5.3.10-1ubuntu3.11`. Discuss/test please.
