### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# SteamDatabase/SteamLinux
+#
+# Executes the SteamLinux tests from Docker:
+#     docker build -t SteamDatabase/SteamLinux .
+#     docker run SteamDatabase/SteamLinux
+FROM ubuntu:trusty
+
+# Install PHPUnit
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get install phpunit -y -q --no-install-recommends
+
+# Add all SteamLinux files
+ADD .phpunit.xml phpunit.xml
+ADD .test.php .test.php
+ADD GAMES.json GAMES.json
+
+# Use PHPUnit to execute the tests
+CMD ["phpunit"]


### PR DESCRIPTION
Use [Docker](http://docker.com) to run the tests, allowing PHPUnit to not be installed locally. Not sure if we'd actually want this in the repository, to be honest. Was just more of an experiment I thought I'd put together.
