### PR TITLE
Trine Enchanted Edition in Open Beta

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -101,6 +101,11 @@
 	"33600": true,
 	"33680": true,
 	"35480": true,
+	"35700":
+	{
+		"Beta": true,
+		"Comment": "Beta access code: TrineEEBetaNovember2014"
+	},
 	"35720": true,
 	"38600":
 	{


### PR DESCRIPTION
While the beta is open to all owners of Trine, it requires a code to access. The code is TrineEEBetaNovember2014
