### PR TITLE
Vanguard Princess (262150) works

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -789,6 +789,10 @@
 	"261960": true,
 	"262060": true,
 	"262100": true,
+	"262150":
+	{
+		"Comment": "Broken overlay."
+	},
 	"262260": true,
 	"262280": true,
 	"262410": true,


### PR DESCRIPTION
Tested on Gentoo Linux, no steam runtime. Steam overlay does not work, but functionally not a problem due to the game being windowed-only and low resolution.