### PR TITLE
A bunch of games tested works - see details

### DIFF
--- a/GAMES.json
+++ b/GAMES.json
@@ -52,7 +52,10 @@
 		"Hidden": true,
 		"Comment": "Demo, not a game."
 	},
-	"1900": true,
+	"1900":
+	{
+		"Comment": "Uses Wine."
+	},
 	"1930":
 	{
 		"Comment": "Uses Wine."
@@ -301,6 +304,18 @@
 	},
 	"210170": true,
 	"210770": true,
+	"211050":
+	{
+		"Beta": true,
+		"Comment": "password: bvscbetalinux. Mail the activation code you can see after clicking Activate by Phone to support@topware.com. Uses Wine.",
+		"CommentURL": "http://steamcommunity.com/games/211050/announcements/detail/834681361294427130"
+	},
+	"211070":
+	{
+		"Beta": true,
+		"Comment": "password: cvsmbetalinux. Mail the activation code you can see after clicking Activate by Phone to support@topware.com. Uses Wine.",
+		"CommentURL": "https://steamcommunity.com/games/211070/announcements/detail/901109320832023642"
+	},
 	"211180": true,
 	"211260": true,
 	"211340":
@@ -337,6 +352,10 @@
 		"Comment": "Server, not a game."
 	},
 	"215510": true,
+	"215930":
+	{
+		"Comment": "Broken overlay. Uses Wine."
+	},
 	"216290": true,
 	"217290": true,
 	"217690": true,
@@ -726,9 +745,12 @@
 	},
 	"253920":
 	{
-		"Comment": "Uses Wine."
+		"Comment": "Broken overlay. Uses Wine."
 	},
-	"253940": true,
+	"253940":
+	{
+		"Comment": "Broken overlay. Uses Wine."
+	},
 	"253980": true,
 	"254200": true,
 	"254320": true,
@@ -793,6 +815,12 @@
 	{
 		"Hidden": true,
 		"Comment": "Beta for 244930."
+	},
+	"261530":
+	{
+		"Beta": true,
+		"Comment": "password: mysteriousPlan",
+		"CommentURL": "http://steamcommunity.com/app/261530/discussions/0/392184522710798797/"
 	},
 	"261640": true,
 	"261680": true,
@@ -1346,6 +1374,7 @@
 		"Comment": "Only 64-bit Launch Config."
 	},
 	"321480": true,
+	"321660": true,
 	"321800": true,
 	"321840": true,
 	"321950": true,
@@ -1661,11 +1690,13 @@
 	},
 	"350000": true,
 	"350010": true,
+	"350090": true,
 	"350150": true,
 	"350210": true,
 	"350740": true,
 	"351060": true,
 	"351140": true,
+	"351300": true,
 	"351330": true,
 	"351450": true,
 	"351480": true,
@@ -1836,6 +1867,7 @@
 	"369550": true,
 	"369560": true,
 	"369580": true,
+	"369620": true,
 	"369890": true,
 	"370020": true,
 	"370050": true,
@@ -1967,6 +1999,7 @@
 	"384990": true,
 	"385030": true,
 	"385060": true,
+	"385080": true,
 	"385150": true,
 	"385250": true,
 	"385270": true,
@@ -2356,12 +2389,14 @@
 	"467940": true,
 	"468490": true,
 	"469710": true,
+	"469930": true,
 	"470030": true,
 	"470270": true,
 	"471770": true,
 	"472060": true,
 	"472420": true,
 	"473140": true,
+	"473470": true,
 	"473520": true,
 	"473670": true,
 	"474010": true,
@@ -2407,6 +2442,7 @@
 	"512470": true,
 	"512740": true,
 	"513460": true,
+	"513560": true,
 	"513580": true,
 	"513620": true,
 	"514650": true,
@@ -2416,6 +2452,7 @@
 	"517910": true,
 	"521340": true,
 	"521470": true,
+	"523070": true,
 	"524650": true,
 	"525780": true,
 	"526540": true,


### PR DESCRIPTION
Earth 2160 (1900) and Septerra Core (253940) uses Wine, Gorky 17 (253920) and Septerra Core (253940) use wine, but have nonworking overlays.

Battle vs Chess (211050) works with beta branch (Wine)
Check vs. Mate (211070) works with beta branch (Wine)
Jagged Alliance 2 - Wildfire (215930) works (Wine)
Lifeless Planet (261530) works with beta branch
Mining Industry (321660) works
No Pineapple Left Behind (350090) works
Ceres (351300) works
F-1 drive (369620) works
Guardians of Victoria (385080) works
Pandum online (469930) works
Purgatory (473470) works
Hunger Dungeon (513560) works
Black Forest (523070) works